### PR TITLE
Updated configuration information

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,17 @@
 ![](./resources/official_armmbed_example_badge.png)
 # System information Mbed OS example
 
-This guide reviews the steps required to get system information onto an Mbed OS enabled platform.
+This example shows how to get system information onto an Mbed OS enabled platform.
 
 You can build this project with all supported [Mbed OS build tools](https://os.mbed.com/docs/mbed-os/latest/tools/index.html). However, this example project specifically refers to the command-line interface tool [Arm Mbed CLI](https://github.com/ARMmbed/mbed-cli#installing-mbed-cli).
 
-## Application functionality
-
-The `main()` function outputs on the serial interface information about the hardware (CPU, ROM and RAM), the firmware (version)and the compiler used to build the binary.
-
-## Prerequisites
-
 1. Install Mbed CLI.
-1. Determine the toolchain that supports your target.
-
-   Depending on the target, the example project can be built with the GCC_ARM, ARM or IAR toolchain. Run this command to determine which toolchain supports your target:
-
-   ```bash
-   $ mbed compile -S
-   ```
-   
 1. Clone this repository on your system.
 1. Change the current directory to where the project was cloned.
+
+## Application functionality
+
+The `main()` function outputs on the serial interface information about the hardware (CPU, ROM and RAM), the firmware (version) and the compiler used to build the binary.
 
 ## Building and running
 
@@ -39,6 +29,12 @@ Your PC may take a few minutes to compile your code.
 The binary is located at `./BUILD/<TARGET>/<TOOLCHAIN>/mbed-os-example-sys-info.bin`.
 
 Alternatively, you can manually copy the binary to the target, which gets mounted on the host computer through USB.
+
+Depending on the target, you can build the example project with the `GCC_ARM`, `ARM` or `IAR` toolchain. After installing Arm Mbed CLI, run the command below to determine which toolchain supports your target:
+
+```bash
+$ mbed compile -S
+```
 
 ## Expected output 
 
@@ -92,6 +88,20 @@ Compiler versions:
 ARM: PVVbbbb (P = Major; VV = Minor; bbbb = build number)
 GCC: VVRRPP  (VV = Version; RR = Revision; PP = Patch)
 IAR: VRRRPPP (V = Version; RRR = Revision; PPP = Patch)
+```
+
+## Configuring the application
+
+You can enable the system statistics feature by setting `platform.sys-stats-enabled` to true in the application configuration file:
+
+```
+{
+    "target_overrides": {
+        "*": {            
+            "platform.sys-stats-enabled": true            
+        }
+    }
+}
 ```
 
 ## Troubleshooting 

--- a/main.cpp
+++ b/main.cpp
@@ -17,7 +17,7 @@
 #include "mbed.h"
 
 #if !defined(MBED_SYS_STATS_ENABLED)
-#error [NOT_SUPPORTED] test not supported
+#error [NOT_SUPPORTED] System statistics not supported
 #endif
 
 int main()

--- a/main.cpp
+++ b/main.cpp
@@ -15,6 +15,7 @@
 * limitations under the License.
 */
 #include "mbed.h"
+#include <inttypes.h>
 
 #if !defined(MBED_SYS_STATS_ENABLED)
 #error [NOT_SUPPORTED] System statistics not supported
@@ -25,7 +26,7 @@ int main()
     mbed_stats_sys_t stats;
     mbed_stats_sys_get(&stats);
 
-    printf("Mbed OS Version: %ld \n", stats.os_version);
+    printf("Mbed OS Version: %" PRId32 "\n", stats.os_version);
 
     /* CPUID Register information
     [31:24]Implementer      0x41 = ARM
@@ -41,7 +42,7 @@ int main()
                             0xD21 = Cortex-M33
     [3:0]Revision           Minor revision: 0x1 = Patch 1
     */
-    printf("CPU ID: 0x%x \n", stats.cpu_id);
+    printf("CPU ID: 0x%" PRIx32 "\n", stats.cpu_id);
 
     /* Compiler IDs
         ARM     = 1
@@ -55,17 +56,17 @@ int main()
        GCC: VVRRPP  (VV = Version; RR = Revision; PP = Patch)
        IAR: VRRRPPP (V = Version; RRR = Revision; PPP = Patch)
     */
-    printf("Compiler Version: %d \n", stats.compiler_version);
+    printf("Compiler Version: %" PRId32 "\n", stats.compiler_version);
 
     /* RAM / ROM memory start and size information */
     for (int i = 0; i < MBED_MAX_MEM_REGIONS; i++) {
         if (stats.ram_size[i] != 0) {
-            printf("RAM%d: Start 0x%lx Size: 0x%lx \n", i, stats.ram_start[i], stats.ram_size[i]);
+            printf("RAM%d: Start 0x%" PRIx32 " Size: 0x%" PRIx32 "\n", i, stats.ram_start[i], stats.ram_size[i]);
         }
     }
     for (int i = 0; i < MBED_MAX_MEM_REGIONS; i++) {
         if (stats.rom_size[i] != 0) {
-            printf("ROM%d: Start 0x%lx Size: 0x%lx \n", i, stats.rom_start[i], stats.rom_size[i]);
+            printf("ROM%d: Start 0x%" PRIx32 " Size: 0x%" PRIx32 "\n", i, stats.rom_start[i], stats.rom_size[i]);
         }
     }
     return 0;

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -1,8 +1,8 @@
 {
-    "macros": ["MBED_SYS_STATS_ENABLED"],
     "target_overrides": {
         "*": {
-            "platform.stdio-convert-newlines": 1
+            "platform.stdio-convert-newlines": 1,
+            "platform.sys-stats-enabled": true
         }
     }
 }

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -1,7 +1,6 @@
 {
     "target_overrides": {
         "*": {
-            "platform.stdio-convert-newlines": 1,
             "platform.sys-stats-enabled": true
         }
     }


### PR DESCRIPTION
Updated README with a configuration section.
Modified `mbed_app.json` to use `platform.sys-stats-enabled` instead of the `MBED_SYS_STATS_ENABLED` macro.